### PR TITLE
Added V5NA/V6NA versioning to PM2.5 output paths

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -14,20 +14,30 @@ polygon_names = config['polygon_name']
 shapefile_years = config['shapefile_year']
 components = config['components']
 components_str = ",".join(components)
-version = config.get('version', 'V5NA')  # V5NA or V6NA — selects data source and directory layout
+version = str(config.get('version', 'V6NA')).strip().upper()  # V5NA or V6NA — selects data source and directory layout
 months_list = [str(i).zfill(2) for i in range(1, 12 + 1)]
 years_list = config['years']
 
-# Map algorithm version to its satellite_component Hydra config group name
-satellite_component_config = {
-    'V5NA': 'us_components_v5na',
-    'V6NA': 'us_components_v6na',
-}.get(version, 'us_components_v5na')
+with open("conf/versions.yaml", "r") as f:
+    versions_cfg = yaml.safe_load(f)
+
+if version not in versions_cfg:
+    raise ValueError(f"Unknown version '{version}'. Expected one of {list(versions_cfg.keys())}.")
+
+version_cfg = versions_cfg[version]
+satellite_component_config = version_cfg["satellite_component"]
+datapaths_config = version_cfg["datapaths"]
+output_label = version_cfg.get("output_label", version)
+script_overrides = (
+    f"satellite_component={satellite_component_config} "
+    f"datapaths={datapaths_config} "
+    f"version={version}"
+)
 
 # === Load Hydra Config ===
-# get hydra config variables from the config.yaml file, applying the version-specific satellite_component
+# get hydra config variables from the config.yaml file, applying the version-specific config groups
 with initialize(version_base=None, config_path="conf"):
-    hydra_cfg = compose(config_name="config", overrides=[f"satellite_component={satellite_component_config}"])
+    hydra_cfg = compose(config_name="config", overrides=script_overrides.split())
 
 satellite_component_cfg = hydra_cfg.satellite_component
 shapefiles_cfg = hydra_cfg.shapefiles
@@ -37,7 +47,12 @@ base_path = datapaths_cfg.base_path if datapaths_cfg.base_path else "data"
 shapefiles_dir = os.path.join(base_path, "input", "shapefiles")
 components_input_pattern = os.path.join(base_path, "input", "components", "{temporal_freq}", "{component}")
 intermediate_pattern = os.path.join(base_path, "intermediate", "{temporal_freq}", "{component}", "{component}__{polygon_name}_{temporal_freq}_{year}.parquet")
-output_pattern = os.path.join(base_path, "output", "{polygon_name}_{temporal_freq}", "pm25_components__randall__{polygon_name}_{temporal_freq}_{year}.parquet")
+output_pattern = os.path.join(
+    base_path,
+    "output",
+    "{polygon_name}_{temporal_freq}",
+    f"pm25_components__randall__{output_label}_{{polygon_name}}_{{temporal_freq}}_{{year}}.parquet",
+)
 
 output_pattern_yearly = output_pattern.replace("{temporal_freq}", "yearly")
 output_pattern_monthly = output_pattern.replace("{temporal_freq}", "monthly")
@@ -64,7 +79,8 @@ rule download_shapefiles:
     output:
         os.path.join(shapefiles_dir, "shapefile_{polygon}_{shapefile_year}", "shapefile.shp")
     shell:
-        "python src/download_shapefile.py polygon_name={wildcards.polygon} shapefile_year={wildcards.shapefile_year}"
+        f"python src/download_shapefile.py {script_overrides} "
+        "polygon_name={wildcards.polygon} shapefile_year={wildcards.shapefile_year}"
 
 # this rule launches the download of all the components. It essentially forces download_component rule to run
 rule download_all_components:
@@ -83,9 +99,7 @@ rule download_component:
     log:
         f"logs/download_components_{{component}}_{{temporal_freq}}_{version}.log"
     shell:
-       f"python src/download_components.py "
-       f"satellite_component={satellite_component_config} "
-       f"++version={version} "
+       f"python src/download_components.py {script_overrides} "
        "component={wildcards.component} ++temporal_freq={wildcards.temporal_freq} &> {log}"
 
 
@@ -106,9 +120,7 @@ rule aggregate_single_component:
         f"logs/aggregate_{{component}}_{{polygon_name}}_{{temporal_freq}}_{{year}}_{version}.log"
     shell:
         (
-            "PYTHONPATH=. python src/aggregate_components.py " +
-            f"satellite_component={satellite_component_config} " +
-            f"++version={version} " +
+            f"PYTHONPATH=. python src/aggregate_components.py {script_overrides} " +
             "polygon_name={wildcards.polygon_name} ++temporal_freq={wildcards.temporal_freq} ++year={wildcards.year} ++component={wildcards.component} " +
             "&> {log}"
         )
@@ -128,9 +140,7 @@ rule merge_components_yearly:
         f"logs/merge_yearly_components_{{polygon_name}}_yearly_{{year}}_{version}.log"
     shell:
         (
-            "PYTHONPATH=. python src/merge_components.py " +
-            f"satellite_component={satellite_component_config} " +
-            f"++version={version} " +
+            f"PYTHONPATH=. python src/merge_components.py {script_overrides} " +
             "polygon_name={wildcards.polygon_name} ++temporal_freq=yearly ++year={wildcards.year} " +
             f"'++components=[{components_str}]' " +
             "&> {log}"
@@ -151,9 +161,7 @@ rule merge_components_monthly:
         f"logs/merge_monthly_components_{{polygon_name}}_monthly_{{year}}_{version}.log"
     shell:
         (
-            "PYTHONPATH=. python src/merge_components.py " +
-            f"satellite_component={satellite_component_config} " +
-            f"++version={version} " +
+            f"PYTHONPATH=. python src/merge_components.py {script_overrides} " +
             "polygon_name={wildcards.polygon_name} ++temporal_freq=monthly ++year={wildcards.year} " +
             f"'++components=[{components_str}]' " +
             "&> {log}"

--- a/conf/versions.yaml
+++ b/conf/versions.yaml
@@ -1,0 +1,9 @@
+V5NA:
+  satellite_component: us_components_v5na
+  datapaths: cannon_v5na
+  output_label: V5NA
+
+V6NA:
+  satellite_component: us_components_v6na
+  datapaths: cannon_v6na
+  output_label: V6NA

--- a/environment.yaml
+++ b/environment.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python
+  - python=3.11
   - netcdf4
   - xarray
   - rasterio

--- a/snakefile.sbatch
+++ b/snakefile.sbatch
@@ -4,4 +4,4 @@
 #SBATCH --mem 128GB # memory per job in the array 
 #SBATCH -t 1-12:00 # time (D-HH:MM) 
 
-snakemake --cores 12 --rerun-incomplete
+snakemake --cores 12 --rerun-incomplete -C version=V5NA

--- a/src/merge_components.py
+++ b/src/merge_components.py
@@ -3,6 +3,7 @@ import hydra
 import logging  
 import pathlib
 import os
+import yaml
 
 from hydra.core.hydra_config import HydraConfig
 
@@ -10,6 +11,20 @@ from hydra.core.hydra_config import HydraConfig
 # configure logger to print at info level
 logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
+VERSIONS_CONFIG = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "conf", "versions.yaml")
+)
+
+
+def output_label_for_version(version):
+    version = str(version).strip().upper()
+    with open(VERSIONS_CONFIG, "r") as f:
+        versions_cfg = yaml.safe_load(f)
+
+    if version not in versions_cfg:
+        raise ValueError(f"Unknown version '{version}'. Expected one of {list(versions_cfg.keys())}.")
+
+    return versions_cfg[version].get("output_label", version)
 
 
 @hydra.main(config_path="../conf", config_name="config", version_base=None)
@@ -68,10 +83,11 @@ def main(cfg):
 
     # == save output file
     output_dir = os.path.join(base_path, "output", f"{cfg.polygon_name}_{cfg.temporal_freq}")
+    output_label = output_label_for_version(cfg.version)
 
     output_filename = os.path.join(
         output_dir,
-        f"pm25_components__randall__{cfg.polygon_name}_{cfg.temporal_freq}_{cfg.year}.parquet",
+        f"pm25_components__randall__{output_label}_{cfg.polygon_name}_{cfg.temporal_freq}_{cfg.year}.parquet",
     )
 
     os.makedirs(output_dir, exist_ok=True)
@@ -79,8 +95,11 @@ def main(cfg):
     output_path = os.path.abspath(output_filename)
     LOGGER.info(f"Saving final output to {output_path}")
     
-    # save to parquet
-    final_df.to_parquet(output_path, index=False)
+    # Write through a temp file so replacing a versioned symlink does not
+    # overwrite the existing unsuffixed parquet that the symlink points to.
+    tmp_output_path = f"{output_path}.tmp"
+    final_df.to_parquet(tmp_output_path, index=False)
+    os.replace(tmp_output_path, output_path)
 
     LOGGER.info(f"Successfully created merged file: {output_path}")
 

--- a/utils/create_dir_paths.py
+++ b/utils/create_dir_paths.py
@@ -1,9 +1,11 @@
 import logging
 import os
 import hydra
+import yaml
 from omegaconf import DictConfig
 
 LOGGER = logging.getLogger(__name__)
+VERSIONS_CONFIG = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "conf", "versions.yaml"))
 
 
 def create_subfolders_and_links(datapath="data", folder_dict=None):
@@ -47,6 +49,66 @@ def create_subfolders_and_links(datapath="data", folder_dict=None):
                     # Recursive call for nested subfolders
                     create_subfolders_and_links(sub_datapath, subfolder_dict)
 
+
+def load_versions_config():
+    with open(VERSIONS_CONFIG, "r") as f:
+        return yaml.safe_load(f)
+
+
+def versioned_output_name(filename, output_label, output_labels):
+    prefix = "pm25_components__randall__"
+
+    if not filename.startswith(prefix) or not filename.endswith(".parquet"):
+        return None
+
+    file_stem = filename.removeprefix(prefix)
+    if any(file_stem.startswith(f"{label}_") for label in output_labels):
+        return None
+
+    return f"{prefix}{output_label}_{file_stem}"
+
+
+def version_from_datapath(datapath, configured_version, versions_cfg):
+    path_parts = {part.upper() for part in os.path.abspath(datapath).split(os.sep)}
+    for version in versions_cfg:
+        if version.upper() in path_parts:
+            return version
+
+    configured_version = str(configured_version).strip().upper()
+    if configured_version not in versions_cfg:
+        raise ValueError(f"Unknown version '{configured_version}'. Expected one of {list(versions_cfg.keys())}.")
+    return configured_version
+
+
+def create_versioned_output_links(datapath, output_label, output_labels):
+    output_root = os.path.join(datapath, "output")
+    if not os.path.exists(output_root):
+        LOGGER.info(f"Output path {output_root} does not exist, skipping versioned output symlinks")
+        return
+
+    for output_dir in os.listdir(output_root):
+        output_path = os.path.join(output_root, output_dir)
+        if not os.path.isdir(output_path):
+            continue
+
+        for filename in os.listdir(output_path):
+            src = os.path.join(output_path, filename)
+            if not os.path.isfile(src):
+                continue
+
+            versioned_name = versioned_output_name(filename, output_label, output_labels)
+            if versioned_name is None:
+                continue
+
+            dst = os.path.join(output_path, versioned_name)
+            if os.path.exists(dst) or os.path.islink(dst):
+                LOGGER.info(f"Versioned output already exists at {dst}")
+                continue
+
+            os.symlink(filename, dst)
+            LOGGER.info(f"Created versioned output symlink {dst} -> {filename}")
+
+
 @hydra.main(config_path="../conf", config_name="config", version_base=None)
 def main(cfg):
     """Create data subfolders and symbolic links as indicated in config file."""
@@ -59,6 +121,15 @@ def main(cfg):
     else:
         LOGGER.info(f"Base path {datapath} already exists")
     create_subfolders_and_links(datapath=datapath, folder_dict=cfg.datapaths.dirs)
+
+    versions_cfg = load_versions_config()
+    version = version_from_datapath(datapath, cfg.get("version", "V6NA"), versions_cfg)
+    output_label = versions_cfg[version].get("output_label", version)
+    output_labels = {
+        version_cfg.get("output_label", version_name)
+        for version_name, version_cfg in versions_cfg.items()
+    }
+    create_versioned_output_links(datapath=datapath, output_label=output_label, output_labels=output_labels)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR adds explicit V5NA/V6NA versioning to the final PM2.5 component output filenames so outputs from both data versions can coexist without overwriting each other.

Final outputs now follow this pattern:

```text
pm25_components__randall__V5NA_county_monthly_2020.parquet
pm25_components__randall__V6NA_county_monthly_2020.parquet
```

## Changes

* Added `conf/versions.yaml` to map each version to:

  * satellite component config
  * datapaths config
  * output label

* Updated `Snakefile` to:

  * read the version from `conf/snakemake.yaml` or a command-line override
  * select the correct `satellite_component` and `datapaths` config for V5NA/V6NA
  * pass version-specific overrides to downstream scripts
  * include the version label in final output targets

* Updated `src/merge_components.py` to:

  * read the output label from `conf/versions.yaml`
  * write final merged files with versioned names
  * write through a temporary file before replacing the final output path, avoiding accidental overwrite of existing unversioned files when symlinks are present

* Updated `utils/create_dir_paths.py` to:

  * read version metadata from `conf/versions.yaml`
  * create versioned symlink aliases for existing unversioned output files when appropriate
  * update the batch run to explicitly use a selected version

Closes #5